### PR TITLE
Fixes to road toolbar and ignores for visual studio files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ projects/*.vcproj.*.user
 projects/*.vcxproj.user
 projects/.vs
 projects/*.db
+projects/*.opendb
 src/rev.cpp
 src/os/windows/ottdres.rc
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ projects/*.sdf
 projects/*.opensdf
 projects/*.vcproj.*.user
 projects/*.vcxproj.user
+projects/.vs
+projects/*.db
 src/rev.cpp
 src/os/windows/ottdres.rc
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -270,8 +270,9 @@ struct BuildRoadToolbarWindow : Window {
 
 	BuildRoadToolbarWindow(WindowDesc *desc, RoadTypeIdentifier roadtype_identifier) : Window(desc)
 	{
+		this->Initialize(roadtype_identifier);
 		this->InitNested(ROADTYPE_ROAD);
-		this->SetupRoadToolbar(roadtype_identifier);
+		this->SetupRoadToolbar();
 		this->SetWidgetsDisabledState(true,
 				WID_ROT_REMOVE,
 				WID_ROT_ONE_WAY,
@@ -310,17 +311,19 @@ struct BuildRoadToolbarWindow : Window {
 		}
 	}
 
+	void Initialize(RoadTypeIdentifier roadtype_identifier)
+	{
+		assert(roadtype_identifier.IsValid());
+		this->roadtype_identifier = roadtype_identifier;
+		this->rti = GetRoadTypeInfo(this->roadtype_identifier);
+	}
+
 	/**
 	* Configures the road toolbar for roadtype given
 	* @param roadtype the roadtype to display
 	*/
-	void SetupRoadToolbar(RoadTypeIdentifier roadtype_identifier)
+	void SetupRoadToolbar()
 	{
-		//assert(roadtype < ROADTYPE_END);
-
-		this->roadtype_identifier = roadtype_identifier;
-		this->rti = GetRoadTypeInfo(roadtype_identifier);
-
 		this->GetWidget<NWidgetCore>(WID_ROT_ROAD_X)->widget_data = rti->gui_sprites.build_x_road;
 		this->GetWidget<NWidgetCore>(WID_ROT_ROAD_Y)->widget_data = rti->gui_sprites.build_y_road;
 		this->GetWidget<NWidgetCore>(WID_ROT_AUTOROAD)->widget_data = rti->gui_sprites.auto_road;
@@ -336,7 +339,8 @@ struct BuildRoadToolbarWindow : Window {
 	*/
 	void ModifyRoadType(RoadTypeIdentifier roadtype_identifier)
 	{
-		this->SetupRoadToolbar(roadtype_identifier);
+		this->Initialize(roadtype_identifier);
+		this->SetupRoadToolbar();
 		this->ReInit();
 	}
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -30,6 +30,7 @@
 #include "road_gui.h"
 #include "zoom_func.h"
 #include "engine_base.h"
+#include "strings_func.h"
 
 #include "widgets/road_widget.h"
 
@@ -342,6 +343,13 @@ struct BuildRoadToolbarWindow : Window {
 		this->Initialize(roadtype_identifier);
 		this->SetupRoadToolbar();
 		this->ReInit();
+	}
+
+	virtual void SetStringParameters(int widget) const
+	{
+		if (widget == WID_ROT_CAPTION) {
+			SetDParam(0, rti->strings.toolbar_caption);
+		}
 	}
 
 	/**
@@ -713,7 +721,7 @@ HotkeyList BuildRoadToolbarWindow::hotkeys("roadtoolbar", roadtoolbar_hotkeys, R
 static const NWidgetPart _nested_build_road_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
-		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_ROAD_TOOLBAR_ROAD_CONSTRUCTION_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
+		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN, WID_ROT_CAPTION), SetDataTip(STR_WHITE_STRING, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 		NWidget(WWT_STICKYBOX, COLOUR_DARK_GREEN),
 	EndContainer(),
 	NWidget(NWID_HORIZONTAL),
@@ -754,7 +762,7 @@ static WindowDesc _build_road_desc(
 static const NWidgetPart _nested_build_tramway_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
-		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_ROAD_TOOLBAR_TRAM_CONSTRUCTION_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
+		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN, WID_ROT_CAPTION), SetDataTip(STR_WHITE_STRING, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 		NWidget(WWT_STICKYBOX, COLOUR_DARK_GREEN),
 	EndContainer(),
 	NWidget(NWID_HORIZONTAL),

--- a/src/widgets/road_widget.h
+++ b/src/widgets/road_widget.h
@@ -15,6 +15,7 @@
 /** Widgets of the #BuildRoadToolbarWindow class. */
 enum RoadToolbarWidgets {
 	/* Name starts with RO instead of R, because of collision with RailToolbarWidgets */
+	WID_ROT_CAPTION,        ///< Caption of the window
 	WID_ROT_ROAD_X,         ///< Build road in x-direction.
 	WID_ROT_ROAD_Y,         ///< Build road in y-direction.
 	WID_ROT_AUTOROAD,       ///< Autorail.


### PR DESCRIPTION
The road/tram construction toolbar wasn't updated to support the caption, I copied the rail toolbar method, but to be able to do it without problems I had to fix the initialization of the toolbar because it started with an invalid roadtype identifier.